### PR TITLE
samples/guestbook: replace panic(wire.Build(...)) with wire.Build(...…

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -105,8 +105,6 @@ func (b *bucket) Delete(ctx context.Context, key string) error {
 	return err
 }
 
-const namingRuleURL = "https://cloud.google.com/storage/docs/naming"
-
 func bufferSize(size int) int {
 	if size == 0 {
 		return googleapi.DefaultUploadChunkSize

--- a/internal/testing/checkpr.sh
+++ b/internal/testing/checkpr.sh
@@ -65,5 +65,5 @@ golangci-lint run \
   --disable=deadcode \
   --disable=typecheck \
   --disable=unused \
-  --disable=varcheck \
+  --build-tags=wireinject \
   "${lintdirs[@]}" || exit 1

--- a/samples/guestbook/inject_aws.go
+++ b/samples/guestbook/inject_aws.go
@@ -38,14 +38,14 @@ import (
 func setupAWS(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		awscloud.AWS,
 		applicationSet,
 		awsBucket,
 		awsMOTDVar,
 		awsSQLParams,
-	))
+	)
+	return nil, nil, nil
 }
 
 // awsBucket is a Wire provider function that returns the S3 bucket based on the

--- a/samples/guestbook/inject_gcp.go
+++ b/samples/guestbook/inject_gcp.go
@@ -38,14 +38,14 @@ import (
 func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		gcpcloud.GCP,
 		applicationSet,
 		gcpBucket,
 		gcpMOTDVar,
 		gcpSQLParams,
-	))
+	)
+	return nil, nil, nil
 }
 
 // gcpBucket is a Wire provider function that returns the GCS bucket based on

--- a/samples/guestbook/inject_local.go
+++ b/samples/guestbook/inject_local.go
@@ -41,8 +41,7 @@ import (
 func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		wire.Value(requestlog.Logger(nil)),
 		wire.Value(trace.Exporter(nil)),
 		server.Set,
@@ -50,7 +49,8 @@ func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), err
 		dialLocalSQL,
 		localBucket,
 		localRuntimeVar,
-	))
+	)
+	return nil, nil, nil
 }
 
 // localBucket is a Wire provider function that returns a directory-based bucket


### PR DESCRIPTION
…), return (#243)

Replace panic(wire.Build(...)) with ...

wire.Build(...)
return foo, bar, baz

https://github.com/golang/go/wiki/CodeReviewComments#dont-panic

Fixes #242